### PR TITLE
chore: add start:railway script for Railway deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
+    "start:railway": "npx prisma migrate deploy && npx prisma db seed && npm run start:prod",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
This commit introduces a new script `start:railway` in package.json to streamline the deployment process on Railway. The script sequentially runs Prisma migrations, seeds the database, and starts the production server.