### PR TITLE
build: add build step to railway start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
-    "start:railway": "npx prisma migrate deploy && npx prisma db seed && npm run start:prod",
+    "start:railway": "npm run build && npx prisma migrate deploy && npx prisma db seed && npm run start:prod",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
Ensure the application is built before running migrations, seeding, and starting in production for Railway deployment