### PR TITLE
chore: update prebuild script to use rm -rf for cross-platform compat…

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "license": "UNLICENSED",
   "scripts": {
-    "prebuild": "rimraf dist",
+    "prebuild": "rm -rf dist || true",
     "build": "nest build",
     "build:railway": "nest build --verbose",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",


### PR DESCRIPTION
…ibility

The prebuild script was modified to use `rm -rf` instead of `rimraf` to ensure compatibility across different operating systems. This change avoids potential issues with the `rimraf` package and simplifies the script.