### PR TITLE
chore: update prebuild script to include prisma generate

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "license": "UNLICENSED",
   "scripts": {
-    "prebuild": "rimraf dist",
+    "prebuild": "rimraf dist && npx prisma generate",
     "build": "nest build",
     "build:railway": "nest build --verbose",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",


### PR DESCRIPTION
The prebuild script now includes `npx prisma generate` to ensure the Prisma client is generated before the build process. This ensures the application has the latest schema changes applied during the build.